### PR TITLE
画面遷移後のテスト方法を修正

### DIFF
--- a/tests/test_search.spec.ts
+++ b/tests/test_search.spec.ts
@@ -5,5 +5,10 @@ test('test', async ({ page }) => {
   await page.getByRole('searchbox', { name: '検索したいキーワードを入力してください' }).click();
   await page.getByRole('searchbox', { name: '検索したいキーワードを入力してください' }).fill('test');
   await page.getByRole('button', { name: '検索' }).click();
-//   await page.getByRole('link', { name: 'Yahoo! JAPAN' }).click();
+  const homeLink = page.getByRole('link', {
+    name: 'Yahoo! JAPAN',
+    exact: true,
+  });
+  await expect(homeLink).toBeVisible();
+  await homeLink.click();
 });


### PR DESCRIPTION
画面遷移後に別のリンクを踏むとエラーになる不具合を修正した

codegenで操作したログをそのままテストコードに貼り付けたが、
遷移した時に何かしらアサーションしないとエラーになるようだ